### PR TITLE
allow automatic reconnection after timeout

### DIFF
--- a/producer/__init__.py
+++ b/producer/__init__.py
@@ -2,20 +2,23 @@ from flask import Flask
 import pika
 
 # Settings
-RABBITMQ_HOST = 'localhost'
-RABBITMQ_PORT = 5672
-RABBITMQ_VHOST = '/'
-RABBITMQ_HEARTBEAT = 600
-RABBITMQ_CONNECTION_TIMEOUT = 300
+class RabbitMQConfig:
+    def __init__(self):
+        self.RABBITMQ_HOST = 'localhost'
+        self.RABBITMQ_PORT = 5672
+        self.RABBITMQ_VHOST = '/'
+        self.RABBITMQ_HEARTBEAT = 10
+        self.RABBITMQ_CONNECTION_TIMEOUT = 5
 
 # Setup rabbitmq connection
 def connect_rabbit():
+    config = RabbitMQConfig()
     credentials = pika.ConnectionParameters(
-        host=RABBITMQ_HOST,
-        port=RABBITMQ_PORT,
-        virtual_host=RABBITMQ_VHOST,
-        heartbeat=RABBITMQ_HEARTBEAT,
-        blocked_connection_timeout=RABBITMQ_CONNECTION_TIMEOUT
+        host=config.RABBITMQ_HOST,
+        port=config.RABBITMQ_PORT,
+        virtual_host=config.RABBITMQ_VHOST,
+        heartbeat=config.RABBITMQ_HEARTBEAT,
+        blocked_connection_timeout=config.RABBITMQ_CONNECTION_TIMEOUT
     )
     connection = pika.BlockingConnection(credentials)
     channel = connection.channel()
@@ -24,5 +27,20 @@ def connect_rabbit():
 
 app = Flask(__name__)
 connection, channel = connect_rabbit()
+
+# Allow reconnection
+def isConnected(func):
+    def inner(*args, **kwargs):
+        global connection
+        global channel
+        try:
+            connection.process_data_events()
+            print("Connection exists.")
+        except (pika.exceptions.ConnectionClosed, pika.exceptions.StreamLostError) as e:
+            print("Connection closed. Reconnecting....")
+            connection, channel = connect_rabbit()
+        return func(*args, **kwargs)
+    inner.__name__ = func.__name__
+    return inner
 
 from . import views

--- a/producer/views.py
+++ b/producer/views.py
@@ -1,13 +1,15 @@
 from flask import jsonify, request
 from flask_api import status
 
-from . import app, channel, connection
+from . import app, isConnected
 from .mq_actions import *
 # setup rabbitmq connection
 
 @app.route('/', methods=['GET', 'POST'])
+@isConnected
 def connectionMethod():
     # POST request
+    from . import channel, connection
     if request.method == 'POST':
         response = switch_connection_status(connection)
     else:    
@@ -15,8 +17,10 @@ def connectionMethod():
     return jsonify({"response": response})
 
 @app.route('/queue', methods=['GET', 'POST'])
+@isConnected
 def queueAction():
     # POST request
+    from . import channel, connection
     if request.method == 'POST':
         try:
             qname = request.form['qname']
@@ -35,8 +39,10 @@ def queueAction():
         return jsonify({"error": str(e)})
 
 @app.route('/queue/<string:qname>', methods=['GET', 'DELETE'])
+@isConnected
 def queueManage(qname):
     # DELETE request
+    from . import channel, connection
     if request.method == 'DELETE':
         try:
             response = delete_queue(channel, qname)
@@ -54,7 +60,9 @@ def queueManage(qname):
         return jsonify({"error": str(e)})
 
 @app.route('/queue/<string:qname>/purge', methods=['POST'])
+@isConnected
 def queuePurge(qname):
+    from . import channel, connection
     try:
         response = purge_queue(channel, qname)
         return jsonify({"response": response})
@@ -63,7 +71,9 @@ def queuePurge(qname):
         return jsonify({"error": str(e)})
 
 @app.route('/queue/<string:qname>/message', methods=['POST'])
+@isConnected
 def messageAction(qname):
+    from . import channel, connection
     message = request.form['message']
     try:
         messageResponse = push_message(channel, qname, message)
@@ -74,7 +84,9 @@ def messageAction(qname):
         return jsonify({"error": str(e)})
 
 @app.route('/queue/<string:qname>/message/<int:mid>', methods=['GET', 'POST'])
+@isConnected
 def messageHandler(qname, mid):
+    from . import channel, connection
     try:
         res_status = status.HTTP_202_ACCEPTED
         if request.method == 'POST':


### PR DESCRIPTION
Issue: #7 
Author: Prakhar
Message: This PR enables automatic reconnection with RabbitMQ, since the initialised connection closes after a certain timeout. 
Also, the `connection.is_open` wasn't helpful is determining the state of connection. This happens because we are using BlockingConnection which is able to check heartbeat only when producer publishes, so inactivity of <timeout> seconds closes the connection. Hence, `connection.process_data_events()` is used in a try catch block to check the actual state, and if found closed then reconnect.